### PR TITLE
Update instruction to disable the net encryption and add a bat script to simplify it

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ echo [SystemSettings] >> "%LocalAppData%\Astro\Saved\Config\WindowsNoEditor\Engi
 echo net.AllowEncryption=False >> "%LocalAppData%\Astro\Saved\Config\WindowsNoEditor\Engine.ini"
 ```
 
+Or, you can use the provided .bat file to modify the client config file
+
+```bash
+clientNetDisableEncryption.bat
+```
+
 ### Configure Router / Firewall
 
 Make sure you configured your router to forward the configured port (default 8777) to your server machine.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,18 @@ To be able to connect to the server you will have to disable encryption on the c
 
 Locate the Engine.ini file on your file system (usually located under `<<User Home>>/AppData/Local/Astro/Saved/Config/WindowsNoEditor)` and add the following line to the bottom of the file:
 
+> win + r %LocalAppData%\Astro\Saved\Config\WindowsNoEditor
+
 ```
 [SystemSettings]
 net.AllowEncryption=False
+```
+
+You can do this the terminal directly:
+
+```bash
+echo [SystemSettings] >> "%LocalAppData%\Astro\Saved\Config\WindowsNoEditor\Engine.ini"
+echo net.AllowEncryption=False >> "%LocalAppData%\Astro\Saved\Config\WindowsNoEditor\Engine.ini"
 ```
 
 ### Configure Router / Firewall
@@ -104,7 +113,7 @@ docker cp <<CONTAINER_ID>>:/backup/<<BACKUP FILE PATH>> ./SAVE_1.savegame
 docker compose stop
 
 # Create but don't start the container
-docker-compose create
+docker compose create
 
 # Get the container id
 docker ps -a

--- a/clientNetDisableEncryption.bat
+++ b/clientNetDisableEncryption.bat
@@ -1,0 +1,8 @@
+@echo off
+set "filePath=%LocalAppData%\Astro\Saved\Config\WindowsNoEditor\Engine.ini"
+
+echo [SystemSettings] >> "%filePath%"
+echo net.AllowEncryption=False >> "%filePath%"
+
+echo Lines added to %filePath%
+pause


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and adds a new batch script to facilitate disabling encryption for server connections. The changes improve user instructions and provide additional methods for modifying configuration files.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14-R33): Added instructions for directly modifying the `Engine.ini` file using the terminal and introduced a new batch script (`clientNetDisableEncryption.bat`) to automate the process.

Codebase updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R122): Updated Docker commands to use the correct `docker compose` syntax instead of `docker-compose`.
* [`clientNetDisableEncryption.bat`](diffhunk://#diff-88a5cae58bb54fd87e3018489a27d14d36c32c23eab033091948780abf62670aR1-R8): Added a new batch script to automate the process of disabling encryption by modifying the `Engine.ini` file.